### PR TITLE
imp [web]: Fix inconsistencies between custom button icons in Form views and List View buttons

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -810,8 +810,9 @@
 <button t-name="ListView.row.button" type="button"
         t-att-title="widget.string" t-att-disabled="disabled || undefined"
         t-att-class="disabled ? 'oe_list_button_disabled' : ''"
-        ><img t-attf-src="#{prefix}/web/static/src/img/icons/#{widget.icon}.png"
-        t-att-alt="widget.string"/></button>
+        ><t t-if="!widget.icon.indexOf('fa-') == 0"><t t-if="!/\//.test(widget.icon)"><img t-attf-src="#{prefix}/web/static/src/img/icons/#{widget.icon}.png" /></t></t>
+        <t t-if="/\//.test(widget.icon)"><img t-attf-src="#{widget.icon}" /></t>
+        <i t-if="widget.icon.indexOf('fa-') == 0" t-attf-class="fa #{widget.icon}" t-att-title="widget.string"/></button>
 <t t-extend="ListView.row">
     <!-- adds back padding to row being rendered after edition, if necessary
          (if not deletable add back padding), otherwise the row being added is


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR aims to fix inconsistencies between custom button icons in form views and list views, There is no condition in `base.xml` to check if the button icon is from an external source or a custom module.

For a better description of this please read my [Stackoverflow answer](http://stackoverflow.com/questions/39412916/how-can-i-add-images-or-icons-inside-a-custom-module-in-odoo-9/39415384#39415384)

Current behavior before PR:
In a form view we can add a custom icon to a button by specifying the full path to the icon. e.g

`<button name="do_stuff" type="object" icon="/my_module/static/src/img/icons/icon.png" />`

This is not the same behaviour for List View icons, even if we specify the full path to the icon, Odoo still appends the default icon location path (`/web/static/src/img/icons`) and `.png` to the icon location. so we end up with a path like this

`<img src="{hostname:port}/web/static/src/img/icons//my_module/static/src/img/icons/icon.png.png" />`

To overcome this, you have to use sleazy hacks like this:
 `<button name="do_stuff" icon="../../../../../my_module/static/src/img/icons/icon" type="object"/>`

this would obviously break, if you decide to move your addon into a custom folder, so it's not a reliable solution.

**Note:** This problem is also present in 9.0

Desired behavior after PR is merged:
Custom ListView button icons can now be declared the same way you would declare a custom icon for a button in a form view.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Fix Inconsistencies between form buttons and Listview buttons
